### PR TITLE
alias of messages to use Errors independently with AMS

### DIFF
--- a/lib/simple_command/errors.rb
+++ b/lib/simple_command/errors.rb
@@ -23,6 +23,7 @@ module SimpleCommand
     def messages
       self
     end
+    alias :errors :messages
 
     def full_messages
       map { |attribute, message| full_message(attribute, message) }

--- a/lib/simple_command/version.rb
+++ b/lib/simple_command/version.rb
@@ -1,3 +1,3 @@
 module SimpleCommand
-  VERSION = '0.0.10'
+  VERSION = '0.0.11'
 end


### PR DESCRIPTION
In order to use SimpleCommand::Errors clas without a command, the Errors instance must have `errors` method.
Example of usage:
```
command = SimpleCommand::Errors.new
command.add(:authorization, ['Not Authorized'])
render json: command, status: :unauthorized, adapter: :json_api, serializer: ActiveModel::Serializer::ErrorSerializer
```